### PR TITLE
fix(frontend): correct CSS import paths in Navbar and Footer components

### DIFF
--- a/frontend/src/Components/Footer.jsx
+++ b/frontend/src/Components/Footer.jsx
@@ -1,4 +1,4 @@
-import "./Footer.css";
+import "../styles/Footer.css";
 
 const Footer = () => {
   return (

--- a/frontend/src/Components/Navbar.jsx
+++ b/frontend/src/Components/Navbar.jsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import "./Navbar.css";
+import "../styles/Navbar.css";
 
 const Navbar = () => {
   return (


### PR DESCRIPTION
## 🐞 Bug Fix: Incorrect CSS import paths

This PR fixes an issue introduced in a previous frontend merge where the `Footer.css` and `Navbar.css` files were incorrectly imported using relative paths that didn't match the project structure.

---

## 🔧 Changes Made

- Fixed `Footer.jsx`: changed `import "./Footer.css"` ➜ `import "../styles/Footer.css"`
- Fixed `Navbar.jsx`: changed `import "./Navbar.css"` ➜ `import "../styles/Navbar.css"`

---

## 🔍 Context

This issue was introduced in the final commit of [#5], where incorrect relative paths to the `styles/` folder caused the components to fail to render styled elements properly.

---

## ✅ Result

- Both components now correctly import their styles.
- No breaking changes introduced.
- Visual layout and styling are restored as intended.

---

## 🏷️ Tags

- `type: fix`
- `area: frontend`
- `status: ready-for-review`
