### PR TITLE
docs: add title field to issue templates for better clarity

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: 🐞 Bug Report
 about: Report a reproducible bug
+title: ""
 labels: bug
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/feature-development.md
+++ b/.github/ISSUE_TEMPLATE/feature-development.md
@@ -1,6 +1,7 @@
 ---
 name: 🚀 Feature Development
 about: Define a development-ready feature with implementation tasks
+title: ""
 labels: enhancement
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/feature-proposal.md
+++ b/.github/ISSUE_TEMPLATE/feature-proposal.md
@@ -1,6 +1,7 @@
 ---
 name: ✨ Feature Proposal
 about: Suggest a new feature or improvement idea
+title: ""
 labels: enhancement
 assignees: ''
 ---


### PR DESCRIPTION
## 📌 Description

This update adds a **title** field to issue templates, improving clarity and organization. With this enhancement, bug reports, feature development, and feature proposals will be easier to structure and reference.

By including a title field, issue creators can provide a clear subject, ensuring better readability and management within the project.

