### PR TITLE
Implement Ticket Purchase Flow with Show and Seat Integration

### DIFF
--- a/backend/src/main/java/com/cinerama/backend/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/cinerama/backend/config/WebSecurityConfig.java
@@ -26,7 +26,7 @@ public class WebSecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/auth/**","/api/tickets").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/com/cinerama/backend/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/cinerama/backend/config/WebSecurityConfig.java
@@ -26,7 +26,8 @@ public class WebSecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**","/api/tickets").permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/user/", "/api/tickets/**").authenticated()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/com/cinerama/backend/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/cinerama/backend/config/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig {
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
         configuration.setAllowCredentials(true);
-        configuration.setMaxAge(3600L); // Opcional: cache de la configuración CORS por 1 hora
+        configuration.setMaxAge(3600L); // 1 hour
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/backend/src/main/java/com/cinerama/backend/controller/TicketController.java
+++ b/backend/src/main/java/com/cinerama/backend/controller/TicketController.java
@@ -19,7 +19,7 @@ public class TicketController {
 
     @PostMapping
     public ResponseEntity<TicketPurchaseResponse> purchaseTicket(@RequestBody TicketPurchaseRequest request) {
-        Long userId = 1L; // Simulado por ahora
+        Long userId = 1L; // Replace with authenticated user ID
         return ResponseEntity.ok(ticketService.purchaseTicket(userId, request));
     }
 }

--- a/backend/src/main/java/com/cinerama/backend/controller/TicketController.java
+++ b/backend/src/main/java/com/cinerama/backend/controller/TicketController.java
@@ -1,0 +1,25 @@
+package com.cinerama.backend.controller;
+
+import com.cinerama.backend.dto.TicketPurchaseRequest;
+import com.cinerama.backend.dto.TicketPurchaseResponse;
+import com.cinerama.backend.service.mail.TicketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/tickets")
+@RequiredArgsConstructor
+
+public class TicketController {
+    private final TicketService ticketService;
+
+    @PostMapping
+    public ResponseEntity<TicketPurchaseResponse> purchaseTicket(@RequestBody TicketPurchaseRequest request) {
+        Long userId = 1L; // Simulado por ahora
+        return ResponseEntity.ok(ticketService.purchaseTicket(userId, request));
+    }
+}

--- a/backend/src/main/java/com/cinerama/backend/dto/TicketPurchaseRequest.java
+++ b/backend/src/main/java/com/cinerama/backend/dto/TicketPurchaseRequest.java
@@ -1,9 +1,16 @@
 package com.cinerama.backend.dto;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
 import java.util.List;
 
+@Data
 public class TicketPurchaseRequest {
+    @NotNull(message = "Show ID is required")
     private Long showId;
+
+    @NotEmpty(message = "At least one seat must be selected")
     private List<Long> seatIds;
 
     public Long getShowId() {

--- a/backend/src/main/java/com/cinerama/backend/dto/TicketPurchaseRequest.java
+++ b/backend/src/main/java/com/cinerama/backend/dto/TicketPurchaseRequest.java
@@ -1,0 +1,8 @@
+package com.cinerama.backend.dto;
+
+import java.util.List;
+
+public class TicketPurchaseRequest {
+    private Long showId;
+    private List<Long> seatIds;
+}

--- a/backend/src/main/java/com/cinerama/backend/dto/TicketPurchaseRequest.java
+++ b/backend/src/main/java/com/cinerama/backend/dto/TicketPurchaseRequest.java
@@ -13,19 +13,5 @@ public class TicketPurchaseRequest {
     @NotEmpty(message = "At least one seat must be selected")
     private List<Long> seatIds;
 
-    public Long getShowId() {
-        return showId;
-    }
 
-    public void setShowId(Long showId) {
-        this.showId = showId;
-    }
-
-    public List<Long> getSeatIds() {
-        return seatIds;
-    }
-
-    public void setSeatIds(List<Long> seatIds) {
-        this.seatIds = seatIds;
-    }
 }

--- a/backend/src/main/java/com/cinerama/backend/dto/TicketPurchaseRequest.java
+++ b/backend/src/main/java/com/cinerama/backend/dto/TicketPurchaseRequest.java
@@ -5,4 +5,20 @@ import java.util.List;
 public class TicketPurchaseRequest {
     private Long showId;
     private List<Long> seatIds;
+
+    public Long getShowId() {
+        return showId;
+    }
+
+    public void setShowId(Long showId) {
+        this.showId = showId;
+    }
+
+    public List<Long> getSeatIds() {
+        return seatIds;
+    }
+
+    public void setSeatIds(List<Long> seatIds) {
+        this.seatIds = seatIds;
+    }
 }

--- a/backend/src/main/java/com/cinerama/backend/dto/TicketPurchaseResponse.java
+++ b/backend/src/main/java/com/cinerama/backend/dto/TicketPurchaseResponse.java
@@ -1,0 +1,17 @@
+package com.cinerama.backend.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class TicketPurchaseResponse {
+    private String confirmationCode;
+    private Long bookingId;
+    private Long showId;
+    private List<String> seats;
+    private LocalDateTime bookingTime;
+    private String message;
+}

--- a/backend/src/main/java/com/cinerama/backend/entity/Booking.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Booking.java
@@ -1,21 +1,32 @@
 package com.cinerama.backend.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
+@Table(name = "booking")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+
 public class Booking {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private Long userId;
 
+    @CreationTimestamp
     private LocalDateTime bookingTime;
     private String confirmationCode;
 
     @ManyToOne
+    @JoinColumn(name = "show_id", nullable = false)
     private Show show;
 
     @ManyToMany
@@ -25,43 +36,7 @@ public class Booking {
             inverseJoinColumns = @JoinColumn(name = "seat_id")
     )
     private List<Seat> seats;
-    // Getters and Setters
-    public Long getId() {
-        return id;
-    }
-    public void setId(Long id) {
-        this.id = id;
-    }
-    public Long getUserId() {
-        return userId;
-    }
-    public void setUserId(Long userId) {
-        this.userId = userId;
-    }
-    public LocalDateTime getBookingTime() {
-        return bookingTime;
-    }
-    public void setBookingTime(LocalDateTime bookingTime) {
-        this.bookingTime = bookingTime;
-    }
-    public String getConfirmationCode() {
-        return confirmationCode;
-    }
-    public void setConfirmationCode(String confirmationCode) {
-        this.confirmationCode = confirmationCode;
-    }
-    public Show getShow() {
-        return show;
-    }
-    public void setShow(Show show) {
-        this.show = show;
-    }
-    public List<Seat> getSeats() {
-        return seats;
-    }
-    public void setSeats(List<Seat> seats) {
-        this.seats = seats;
-    }
+
     @Override
     public String toString() {
         return "Booking{" +

--- a/backend/src/main/java/com/cinerama/backend/entity/Booking.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Booking.java
@@ -1,0 +1,23 @@
+package com.cinerama.backend.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+public class Booking {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private LocalDateTime bookingTime;
+    private String confirmationCode;
+
+    @ManyToOne
+    private Show show;
+
+    @ManyToMany
+    private List<Seat> seats;
+}

--- a/backend/src/main/java/com/cinerama/backend/entity/Booking.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Booking.java
@@ -19,5 +19,58 @@ public class Booking {
     private Show show;
 
     @ManyToMany
+    @JoinTable(
+            name = "booking_seat",
+            joinColumns = @JoinColumn(name = "booking_id"),
+            inverseJoinColumns = @JoinColumn(name = "seat_id")
+    )
     private List<Seat> seats;
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+    public void setId(Long id) {
+        this.id = id;
+    }
+    public Long getUserId() {
+        return userId;
+    }
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+    public LocalDateTime getBookingTime() {
+        return bookingTime;
+    }
+    public void setBookingTime(LocalDateTime bookingTime) {
+        this.bookingTime = bookingTime;
+    }
+    public String getConfirmationCode() {
+        return confirmationCode;
+    }
+    public void setConfirmationCode(String confirmationCode) {
+        this.confirmationCode = confirmationCode;
+    }
+    public Show getShow() {
+        return show;
+    }
+    public void setShow(Show show) {
+        this.show = show;
+    }
+    public List<Seat> getSeats() {
+        return seats;
+    }
+    public void setSeats(List<Seat> seats) {
+        this.seats = seats;
+    }
+    @Override
+    public String toString() {
+        return "Booking{" +
+                "id=" + id +
+                ", userId=" + userId +
+                ", bookingTime=" + bookingTime +
+                ", confirmationCode='" + confirmationCode + '\'' +
+                ", show=" + show +
+                ", seats=" + seats +
+                '}';
+    }
 }

--- a/backend/src/main/java/com/cinerama/backend/entity/Seat.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Seat.java
@@ -14,4 +14,36 @@ public class Seat {
 
     @ManyToOne
     private Show show;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSeatNumber() {
+        return seatNumber;
+    }
+
+    public void setSeatNumber(String seatNumber) {
+        this.seatNumber = seatNumber;
+    }
+
+    public boolean isAvailable() {
+        return available;
+    }
+
+    public void setAvailable(boolean available) {
+        this.available = available;
+    }
+
+    public Show getShow() {
+        return show;
+    }
+
+    public void setShow(Show show) {
+        this.show = show;
+    }
 }

--- a/backend/src/main/java/com/cinerama/backend/entity/Seat.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Seat.java
@@ -1,0 +1,17 @@
+package com.cinerama.backend.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Seat {
+    @Id
+    private Long id;
+
+    private String seatNumber;
+    private boolean available;
+
+    @ManyToOne
+    private Show show;
+}

--- a/backend/src/main/java/com/cinerama/backend/entity/Seat.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Seat.java
@@ -1,49 +1,29 @@
 package com.cinerama.backend.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
+@Table(name = "seat")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+
 public class Seat {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String seatNumber;
+
+    @Column(nullable = false)
     private boolean available;
 
     @ManyToOne
+    @JoinColumn(name = "show_id", nullable = false)
     private Show show;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getSeatNumber() {
-        return seatNumber;
-    }
-
-    public void setSeatNumber(String seatNumber) {
-        this.seatNumber = seatNumber;
-    }
-
-    public boolean isAvailable() {
-        return available;
-    }
-
-    public void setAvailable(boolean available) {
-        this.available = available;
-    }
-
-    public Show getShow() {
-        return show;
-    }
-
-    public void setShow(Show show) {
-        this.show = show;
-    }
 }

--- a/backend/src/main/java/com/cinerama/backend/entity/Show.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Show.java
@@ -1,50 +1,36 @@
 package com.cinerama.backend.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.List;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "movie_show")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+
 public class Show {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "movie_title", nullable = false)
     private String movieTitle;
+
+    @Column(name = "start_time", nullable = false)
     private LocalDateTime startTime;
+
+    @Column(name = "end_time", nullable = false)
     private LocalDateTime endTime;
 
-    public Long getId() {
-        return id;
-    }
+    @OneToMany(mappedBy = "show", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Seat> seats;
+    @OneToMany(mappedBy = "show", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Booking> bookings;
+    // Getters and Setters
 
-    public void setId(Long id) {
-        this.id = id;
-    }
 
-    public String getMovieTitle() {
-        return movieTitle;
-    }
-
-    public void setMovieTitle(String movieTitle) {
-        this.movieTitle = movieTitle;
-    }
-
-    public LocalDateTime getStartTime() {
-        return startTime;
-    }
-
-    public void setStartTime(LocalDateTime startTime) {
-        this.startTime = startTime;
-    }
-
-    public LocalDateTime getEndTime() {
-        return endTime;
-    }
-
-    public void setEndTime(LocalDateTime endTime) {
-        this.endTime = endTime;
-    }
 }

--- a/backend/src/main/java/com/cinerama/backend/entity/Show.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Show.java
@@ -11,4 +11,37 @@ public class Show {
 
     private String movieTitle;
     private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getMovieTitle() {
+        return movieTitle;
+    }
+
+    public void setMovieTitle(String movieTitle) {
+        this.movieTitle = movieTitle;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
 }

--- a/backend/src/main/java/com/cinerama/backend/entity/Show.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Show.java
@@ -2,9 +2,12 @@ package com.cinerama.backend.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
 import java.time.LocalDateTime;
 
 @Entity
+@Table(name = "movie_show")
 public class Show {
     @Id
     private Long id;

--- a/backend/src/main/java/com/cinerama/backend/entity/Show.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Show.java
@@ -1,0 +1,14 @@
+package com.cinerama.backend.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+
+@Entity
+public class Show {
+    @Id
+    private Long id;
+
+    private String movieTitle;
+    private LocalDateTime startTime;
+}

--- a/backend/src/main/java/com/cinerama/backend/repository/BookingRepository.java
+++ b/backend/src/main/java/com/cinerama/backend/repository/BookingRepository.java
@@ -1,0 +1,8 @@
+package com.cinerama.backend.repository;
+
+import com.cinerama.backend.entity.Booking;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookingRepository extends JpaRepository<Booking, Long> {
+
+  }

--- a/backend/src/main/java/com/cinerama/backend/repository/SeatRepository.java
+++ b/backend/src/main/java/com/cinerama/backend/repository/SeatRepository.java
@@ -1,0 +1,9 @@
+package com.cinerama.backend.repository;
+
+import com.cinerama.backend.entity.Seat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+    List<Seat> findAllByIdInAndAvailableTrue(List<Long> ids);
+}

--- a/backend/src/main/java/com/cinerama/backend/repository/ShowRepository.java
+++ b/backend/src/main/java/com/cinerama/backend/repository/ShowRepository.java
@@ -1,0 +1,7 @@
+package com.cinerama.backend.repository;
+
+import com.cinerama.backend.entity.Show;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShowRepository extends JpaRepository<Show, Long> {
+}

--- a/backend/src/main/java/com/cinerama/backend/service/impl/TicketServiceImpl.java
+++ b/backend/src/main/java/com/cinerama/backend/service/impl/TicketServiceImpl.java
@@ -1,0 +1,59 @@
+package com.cinerama.backend.service.impl;
+
+import com.cinerama.backend.dto.TicketPurchaseRequest;
+import com.cinerama.backend.dto.TicketPurchaseResponse;
+import com.cinerama.backend.entity.Booking;
+import com.cinerama.backend.entity.Seat;
+import com.cinerama.backend.entity.Show;
+import com.cinerama.backend.repository.BookingRepository;
+import com.cinerama.backend.repository.SeatRepository;
+import com.cinerama.backend.repository.ShowRepository;
+import com.cinerama.backend.service.mail.TicketService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TicketServiceImpl implements TicketService {
+    private final ShowRepository showRepository;
+    private final SeatRepository seatRepository;
+    private final BookingRepository bookingRepository;
+
+    @Transactional
+    public TicketPurchaseResponse purchaseTicket(Long userId, TicketPurchaseRequest request) {
+        Show show = showRepository.findById(request.getShowId())
+                .orElseThrow(() -> new IllegalArgumentException("Show not found"));
+
+        List<Seat> availableSeats = seatRepository.findAllByIdInAndAvailableTrue(request.getSeatIds());
+
+        if (availableSeats.size() != request.getSeatIds().size()) {
+            throw new IllegalStateException("Some seats are already booked");
+        }
+
+        availableSeats.forEach(seat -> seat.setAvailable(false));
+        seatRepository.saveAll(availableSeats);
+
+        Booking booking = new Booking();
+        booking.setUserId(userId);
+        booking.setShow(show);
+        booking.setBookingTime(LocalDateTime.now());
+        booking.setConfirmationCode(UUID.randomUUID().toString());
+        booking.setSeats(availableSeats);
+
+        bookingRepository.save(booking);
+
+        return TicketPurchaseResponse.builder()
+                .confirmationCode(booking.getConfirmationCode())
+                .bookingId(booking.getId())
+                .showId(show.getId())
+                .bookingTime(booking.getBookingTime())
+                .seats(availableSeats.stream().map(Seat::getSeatNumber).toList())
+                .message("Ticket purchase successful")
+                .build();
+    }
+}

--- a/backend/src/main/java/com/cinerama/backend/service/mail/TicketService.java
+++ b/backend/src/main/java/com/cinerama/backend/service/mail/TicketService.java
@@ -1,0 +1,8 @@
+package com.cinerama.backend.service.mail;
+
+import com.cinerama.backend.dto.TicketPurchaseRequest;
+import com.cinerama.backend.dto.TicketPurchaseResponse;
+
+public interface TicketService {
+    TicketPurchaseResponse purchaseTicket(Long userId, TicketPurchaseRequest request);
+}


### PR DESCRIPTION
## 📌 Description

This pull request introduces the initial backend logic for ticket purchasing. It includes:
- Endpoint for purchasing tickets (`POST /api/tickets`)
- Validation of seat availability
- Booking persistence with confirmation code generation
- Basic JWT-based authentication (mocked user ID for now)

Note: Seat selection logic and user role integration are not yet finalized, as these are being developed by other team members.

Closes: #24 

---

## ✅ Checklist

- [x] Code compiles and runs correctly
- [x] All existing and new tests pass
- [x] Follows coding conventions/style
- [x] No unnecessary console.logs or commented code
- [x] Proper error handling implemented
- [ ] Responsive design (if applicable)
- [x] Connected to backend (if required)

---

## 🧪 How to Test

1. Run the backend service.
2. In Postman, send a POST request to:
```
http://localhost:8080/api/tickets
```
with a body like:

```
{
  "showId": 1,
  "seatIds": [1, 2]
}
```
3. Ensure:
- A booking is created
- The selected seats are marked unavailable
- A confirmation code is returned in the response

⚠️ Make sure your database has test data:
- At least one movie_show with ID 1
- Available seats with IDs 1, 2 linked to that show
---

## 📷 Screenshots 

| ![image](https://github.com/user-attachments/assets/287ced29-b425-43b6-b8b4-c0f827e79780) | 

---

## 💬 Additional Notes

- Currently uses a hardcoded user ID (1L); replace with actual user from JWT once authentication is fully implemented
- Seat locking is basic; future improvement could involve optimistic locking or database transactions
- Make sure the show and seats exist in the database before testing
