### PR TITLE
Add Seat Reservation Endpoint with Detailed Response

### DIFF
--- a/backend/src/main/java/com/cinerama/backend/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/cinerama/backend/config/WebSecurityConfig.java
@@ -95,8 +95,8 @@ public class WebSecurityConfig {
                 // Configure endpoint authorization rules
                 .authorizeHttpRequests(auth -> auth
                         // Public endpoints for user authentication (register, login, verify)
-                        .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/api/user/", "/api/tickets/**").authenticated()
+                        .requestMatchers("/api/auth/**", "/api/seats/available**").permitAll()
+                        .requestMatchers("/api/user/", "/api/seats/reserve", "/api/tickets/**", "/api/seats/**").authenticated()
 
                         // All other endpoints require authentication
                         .anyRequest().authenticated()

--- a/backend/src/main/java/com/cinerama/backend/controller/SeatController.java
+++ b/backend/src/main/java/com/cinerama/backend/controller/SeatController.java
@@ -1,0 +1,64 @@
+package com.cinerama.backend.controller;
+
+import com.cinerama.backend.entity.Seat;
+import com.cinerama.backend.service.impl.SeatServiceImpl;
+import lombok.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@RestController
+@RequestMapping("/api/seats")
+@RequiredArgsConstructor
+public class SeatController {
+    private final SeatServiceImpl seatServiceImpl;
+
+    @GetMapping("/available")
+    public ResponseEntity<List<Map<String, Object>>> getAvailableSeats(@RequestParam Long showId) {
+        List<Seat> seats = seatServiceImpl.getAvailableSeats(showId);
+        List<Map<String, Object>> response = new ArrayList<>();
+
+        for (Seat seat : seats) {
+            Map<String, Object> seatData = new HashMap<>();
+            seatData.put("id", seat.getId());
+            seatData.put("seatNumber", seat.getSeatNumber());
+            seatData.put("type", seat.getType());
+            seatData.put("price", seat.getPrice());
+            seatData.put("available", seat.isAvailable());
+            response.add(seatData);
+        }
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/reserve")
+    public ResponseEntity<?> reserveSeats(@RequestBody ReserveRequest request) {
+        try {
+            List<Seat> reservedSeats = seatServiceImpl.reserveSeats(request.getShowId(), request.getSeatIds());
+            List<Map<String, Object>> reservedInfo = new ArrayList<>();
+
+            for (Seat seat : reservedSeats) {
+                Map<String, Object> s = new HashMap<>();
+                s.put("seatNumber", seat.getSeatNumber());
+                s.put("price", seat.getPrice());
+                s.put("type", seat.getType());
+                reservedInfo.add(s);
+            }
+
+            return ResponseEntity.ok(Map.of(
+                    "message", "Seats successfully reserved",
+                    "reservedSeats", reservedInfo
+            ));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Data
+    public static class ReserveRequest {
+        private Long showId;
+        private List<Long> seatIds;
+    }
+}

--- a/backend/src/main/java/com/cinerama/backend/entity/Room.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Room.java
@@ -1,0 +1,33 @@
+package com.cinerama.backend.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.List;
+
+@Entity
+@Table(name = "room")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Room {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(nullable = false)
+    private int capacity;
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Seat> seats;
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Show> shows;
+}
+
+

--- a/backend/src/main/java/com/cinerama/backend/entity/Seat.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Seat.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Entity
 @Table(name = "seat")
 @Data
@@ -20,7 +22,17 @@ public class Seat {
     private String seatNumber;
 
     @Column(nullable = false)
+    private String type;
+
+    @Column(nullable = false)
+    private BigDecimal price;
+
+    @Column(nullable = false)
     private boolean available;
+
+    @ManyToOne
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
 
     @ManyToOne
     @JoinColumn(name = "show_id", nullable = false)

--- a/backend/src/main/java/com/cinerama/backend/entity/Show.java
+++ b/backend/src/main/java/com/cinerama/backend/entity/Show.java
@@ -30,7 +30,11 @@ public class Show {
     private List<Seat> seats;
     @OneToMany(mappedBy = "show", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Booking> bookings;
+
+    @ManyToOne
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
     // Getters and Setters
 
-
 }
+

--- a/backend/src/main/java/com/cinerama/backend/repository/SeatRepository.java
+++ b/backend/src/main/java/com/cinerama/backend/repository/SeatRepository.java
@@ -1,9 +1,12 @@
 package com.cinerama.backend.repository;
 
 import com.cinerama.backend.entity.Seat;
+import jakarta.validation.constraints.NotEmpty;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
-    List<Seat> findAllByIdInAndAvailableTrue(List<Long> ids);
+    List<Seat> findByShowIdAndAvailableTrue(Long showId);
+    List<Seat> findByIdIn(List<Long> ids);
+    List<Seat> findAllByIdInAndAvailableTrue(@NotEmpty(message = "At least one seat must be selected") List<Long> seatIds);
 }

--- a/backend/src/main/java/com/cinerama/backend/service/SeatService.java
+++ b/backend/src/main/java/com/cinerama/backend/service/SeatService.java
@@ -1,0 +1,10 @@
+package com.cinerama.backend.service;
+
+import com.cinerama.backend.entity.Seat;
+
+import java.util.List;
+
+public interface SeatService {
+    List<Seat> getAvailableSeats(Long showId);
+    List<Seat> reserveSeats(Long showId, List<Long> seatIds);
+}

--- a/backend/src/main/java/com/cinerama/backend/service/impl/SeatServiceImpl.java
+++ b/backend/src/main/java/com/cinerama/backend/service/impl/SeatServiceImpl.java
@@ -1,0 +1,39 @@
+package com.cinerama.backend.service.impl;
+
+import com.cinerama.backend.entity.Seat;
+import com.cinerama.backend.repository.SeatRepository;
+import com.cinerama.backend.service.SeatService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SeatServiceImpl implements SeatService {
+    private final SeatRepository seatRepository;
+
+    @Override
+    public List<Seat> getAvailableSeats(Long showId) {
+        return seatRepository.findByShowIdAndAvailableTrue(showId);
+    }
+
+    @Override
+    @Transactional
+    public List<Seat> reserveSeats(Long showId, List<Long> seatIds) {
+        List<Seat> seats = seatRepository.findByIdIn(seatIds);
+
+        for (Seat seat : seats) {
+            if (!seat.isAvailable()) {
+                throw new RuntimeException("The seat " + seat.getSeatNumber() + " is already reserved");
+            }
+            if (!seat.getShow().getId().equals(showId)) {
+                throw new RuntimeException("The seat " + seat.getSeatNumber() + " does not belong to the show");
+            }
+            seat.setAvailable(false);
+        }
+
+        return seatRepository.saveAll(seats);
+    }
+}


### PR DESCRIPTION
## 📌 Description

This Pull Request implements the reservation functionality for movie show seats.  
It adds the ability to reserve specific seats for a given show and returns a clear response with the reserved seats' details (seat number, price, and type).


Closes: #36

---

## ✅ Checklist

- [x] Code compiles and runs correctly
- [x] All existing and new tests pass
- [x] Follows coding conventions/style
- [x] No unnecessary console.logs or commented code
- [x] Proper error handling implemented

---

## 💬 Additional Notes

- The frontend integration is the next step: we will use the reservedSeats response to show a visual confirmation of seat booking.
- Further enhancements may include seat selection UI, real-time availability updates, and cancellation support.
- Additional testing for edge cases (e.g. race conditions when reserving seats simultaneously) may be considered.
- We may later introduce seat pricing logic by room type or promotion.
