### PR TITLE
fix(logging): reduce logging verbosity for Spring, Hibernate, and app…

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -11,10 +11,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
-        '[format_sql]': true
+        '[format_sql]': false
+        '[use_sql_comments]': false
 
   datasource:
     url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:cinerama_db}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=${DB_TIMEZONE:America/Lima}
@@ -39,8 +40,11 @@ jwt:
   expiration: ${JWT_EXPIRATION}
 logging:
   level:
-    '[org.springframework]': INFO
-    '[com.cinerama]': DEBUG
+    '[org.springframework]': WARN
+    '[com.cinerama]': INFO
+    '[org.hibernate]': WARN
+    '[com.zaxxer.hikari]': WARN
+    '[reactor.netty]': WARN
 
 paypal:
   client-id: ${PAYPAL_CLIENT_ID}

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -63,16 +63,24 @@
     </appender>
 
     <!-- Logger for Spring Framework -->
-    <logger name="org.springframework" level="INFO"/>
+    <logger name="org.springframework" level="WARN"/>
+
+    <!-- Logger for Hibernate (reduce SQL logging) -->
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="org.hibernate.SQL" level="WARN"/>
+    <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="WARN"/>
+    <logger name="org.hibernate.orm" level="WARN"/>
+
+    <!-- Logger for HikariCP connection pool -->
+    <logger name="com.zaxxer.hikari" level="WARN"/>
 
     <!-- Logger for the application -->
-    <logger name="com.cinerama" level="DEBUG"/>
+    <logger name="com.cinerama" level="INFO"/>
 
     <!-- Root Logger -->
-    <root level="DEBUG">
+    <root level="WARN">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="INFO_FILE"/>
-        <appender-ref ref="DEBUG_FILE"/>
         <appender-ref ref="ERROR_FILE"/>
     </root>
 


### PR DESCRIPTION
This pull request focuses on reducing the verbosity of SQL and application logging in both the Spring Boot configuration and Logback logging setup. The changes are aimed at minimizing unnecessary log output, especially for SQL statements and debug-level logs, to make logs more manageable and production-ready.

**Logging configuration adjustments:**

* Lowered the log level for `org.springframework`, `org.hibernate`, `com.zaxxer.hikari`, and `reactor.netty` to `WARN` in `application.yml` to reduce noise from framework and database connection pool logs. The application's own log level (`com.cinerama`) was raised from `DEBUG` to `INFO`.
* Updated `logback-spring.xml` to match the new log levels: set `org.springframework`, `org.hibernate`, and related Hibernate loggers to `WARN`, and raised `com.cinerama` to `INFO`. The root logger was also changed from `DEBUG` to `WARN` to further limit log output.

**SQL output reduction:**

* Disabled SQL statement output and formatting in Hibernate by setting `show-sql`, `format_sql`, and `use_sql_comments` to `false` in `application.yml`. This prevents SQL queries from flooding the logs